### PR TITLE
Start WIP release notes for 1.12 with kubelet config notes

### DIFF
--- a/pages/release-notes/00000000-0.00
+++ b/pages/release-notes/00000000-0.00
@@ -2,11 +2,13 @@
 
 Short intro paragraph that details highlights or significant changes, possibly with links
 
-## New
+- First new feature
 
- - List items
- - detailing new 
- - features
+Details for first new feature, if needed.
+
+- Second new feature
+
+Details for second new feature, if needed.
 
 ## Fixes
 
@@ -18,9 +20,9 @@ Short intro paragraph that details highlights or significant changes, possibly w
 
  - any remaining major issues currently being worked on
  - for the next release
- - if any 
-
+ - if any
 
 ## Contact Us
 
-Some boilerplate text indicating where to file new issues, discuss stuff etc.
+- Issues: https://github.com/juju-solutions/bundle-canonical-kubernetes/issues
+- IRC: #juju on freenode.net

--- a/pages/release-notes/20180817-1.12
+++ b/pages/release-notes/20180817-1.12
@@ -1,0 +1,47 @@
+# 1.12 Release Notes WIP
+
+TODO: Short intro paragraph that details highlights or significant changes, possibly with links
+
+- New kubernetes-worker charm config: kubelet-extra-config
+
+In Kubernetes 1.10, a new KubeletConfiguration file was introduced, and many of
+Kubelet's command line options were moved there and marked as deprecated. In
+order to accomodate this change, we've introduced a new charm config to
+kubernetes-worker: `kubelet-extra-config`.
+
+This config can be used to override KubeletConfiguration values provided by
+the charm, and is usable on any Canonical cluster running Kubernetes 1.10+.
+
+The value for this config must be a YAML mapping that can be safely
+merged with a KubeletConfiguration file. For example:
+```
+juju config kubernetes-worker kubelet-extra-config="{evictionHard: {memory.available: 200Mi}}"
+```
+
+For more information about KubeletConfiguration, see upstream docs:
+https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
+
+- Added support for Dynamic Kubelet Configuration
+
+While we recommend `kubelet-extra-config` as a more robust and approachable way
+to configure Kubelet, we've also made it possible to configure kubelet using
+the Dynamic Kubelet Configuration feature that comes with Kubernetes 1.11+. You
+can read about that here:
+https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/
+
+## Fixes
+
+ - list items
+ - linked to fixed bugs
+ - where relevant
+
+## Known issues
+
+ - any remaining major issues currently being worked on
+ - for the next release
+ - if any 
+
+## Contact Us
+
+- Issues: https://github.com/juju-solutions/bundle-canonical-kubernetes/issues
+- IRC: #juju on freenode.net


### PR DESCRIPTION
Hey @evilnick - thanks again for getting me started on this.

I've proposed a change to the template that drops the `## New` section and just includes new features as items within the summary section, with room for details. That's how Juju did it for 2.4.0 so I thought it might make sense for us to follow their lead, but I'm open to anything as long as we can include details easily.

One question: what's the intention for the YYYYMMDD in the filename? We don't have our releases scheduled ahead of time, so I just picked today's date.