### PR TITLE
Add proxy config to 1.12 release notes

### DIFF
--- a/pages/release-notes/20180817-1.12
+++ b/pages/release-notes/20180817-1.12
@@ -50,6 +50,14 @@ determined by the configuration of [Juju endpoint bindings](https://docs.jujucha
 
 Special thanks to [@rmescandon](https://github.com/rmescandon) for this contribution!
 
+- Updated proxy configuration
+
+For operators who currently use the `http-proxy`, `https-proxy` and `no-proxy`
+Juju model configs, we recommend using the newer `juju-http-proxy`,
+`juju-https-proxy` and `juju-no-proxy` model configs instead. See the
+[Proxy configuration](https://github.com/juju-solutions/bundle-canonical-kubernetes/wiki/Proxy-configuration)
+page for details.
+
 ## Fixes
 
 - Fixed kube-dns constantly restarting on 18.04 ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/655))


### PR DESCRIPTION
Requested by IS here: https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/676#issuecomment-431267884

I think it makes sense - we've updated our recommendations on how to configure proxy settings for CDK, and the release notes are a good vehicle for informing users of that change.