### PR TITLE
Move release notes, add docs links

### DIFF
--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -91,9 +91,6 @@ virtual IP. For more details, please see the [documentation][docs-keepalived].
 ## Known issues
 
  - A [current bug](https://github.com/kubernetes/kubernetes/issues/70044) in Kubernetes could prevent the upgrade from properly deleting old pods. `kubectl delete pod <pod_name> --force --grace-period=0` can be used to clean them up.
- - any remaining major issues currently being worked on
- - for the next release
- - if any
 
 ## Contact Us
 

--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -4,7 +4,7 @@ markdown_includes:
   nav: "shared/_side-navigation.md"
 context:
   title: "Release notes"
-  description: Release notes for version 1.12
+  description: Release notes for CDK
 keywords: kubernetes, news, release, notes
 tags: [news]
 sidebar: k8smain-sidebar
@@ -12,6 +12,97 @@ permalink: release-notes.html
 layout: [base, ubuntu-com]
 toc: False
 ---
+
+# 1.13 Release Notes
+
+## What's new
+
+- LDAP and Keystone support
+
+Added support for LDAP-based authentication and authorisation via Keystone. Please
+read the [documentation][docs-ldap] for details on how to enable this.
+
+- Vault PKI support
+
+Added support for using [Vault](https://jujucharms.com/u/openstack-charmers/vault/)
+for PKI in place of EasyRSA. Vault is more secure and robust than EasyRSA and supports
+more advanced features for certificate management. See the
+[documentation][docs-vault] for details of how to add Vault to CDK and configure it as a
+root or intermediary CA.
+
+- Encryption-at-rest support using Vault
+
+Added support for encryption-at-rest for cluster secrets, leveraging
+[Vault](https://jujucharms.com/u/openstack-charmers/vault/) for data protection. This
+ensures that even the keys used to encrypt the data are protected at rest, unlike many
+configurations of encryption-at-rest for Kubernetes. Please see the
+[documentation][docs-ear] for further details.
+
+- Private Docker registry support
+
+Added support for the [Docker Registry](https://jujucharms.com/u/containers/docker-registry)
+charm to provide Docker images to cluster components without requiring access to
+public registries. Full instructions on using this feature are in the [documentation][docs-registry].
+
+- Keepalived support
+
+The keepalived charm can be used to run multiple kube-api-loadbalancers behind a
+virtual IP. For more details, please see the [documentation][docs-keepalived].
+
+## Fixes
+
+ - Added post deployment script for jaas/jujushell ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/pull/697))
+ - Added support for load-balancer failover ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/453))
+ - Added always restart for etcd ([Issue](https://github.com/juju-solutions/layer-etcd/pull/145))
+ - Added Xenial support to Azure integrator ([Issue](https://github.com/juju-solutions/charm-azure-integrator/pull/17))
+ - Added Bionic support to Openstack integrator ([Issue](https://github.com/juju-solutions/charm-openstack-integrator/pull/13))
+ - Added support for ELB service-linked role ([Issue](https://github.com/juju-solutions/charm-aws-integrator/pull/29))
+ - Added ability to configure Docker install source ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/621))
+ - Fixed EasyRSA does not run as an LXD container on 18.04 ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/654))
+ - Fixed ceph volumes cannot be attached to the pods after 1.12 ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/662))
+ - Fixed ceph volumes fail to attach with "node has no NodeID annotation" ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/675))
+ - Fixed ceph-xfs volumes failing to format due to "executable file not found in $PATH" ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/668))
+ - Fixed ceph volumes not detaching properly ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/669))
+ - Fixed ceph-csi addons not getting cleaned up properly ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/680))
+ - Fixed Calico/Canal not working with kube-proxy on master ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/660))
+ - Fixed issue with Canal charm not populating the kubeconfig option in 10-canal.conflist ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/671))
+ - Fixed cannot access logs after enabling RBAC ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/642))
+ - Fixed RBAC breaking prometheus/grafana metric collection ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/635))
+ - Fixed upstream Docker charm config option using wrong package source ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/620))
+ - Fixed a timing issue where ceph can appear broken when it's not ([Issue](https://github.com/juju-solutions/kubernetes/pull/173))
+ - Fixed status when cni is not ready ([Issue](https://github.com/juju-solutions/kubernetes/pull/174))
+ - Fixed an issue with calico-node service failures not surfacing ([Issue](https://github.com/juju-solutions/layer-calico/pull/28))
+ - Fixed empty configuration due to timing issue with cni. ([Issue](https://github.com/juju-solutions/layer-canal/pull/22))
+ - Fixed an issue where the calico-node service failed to start ([Issue](https://github.com/juju-solutions/layer-canal/pull/24))
+ - Fixed updating policy definitions during upgrade-charm on AWS integrator ([Issue](https://github.com/juju-solutions/charm-aws-integrator/pull/30))
+ - Fixed parsing credentials config value ([Issue](https://github.com/juju-solutions/charm-azure-integrator/pull/18))
+ - Fixed pvc stuck in pending ([Issue](https://github.com/juju-solutions/charm-azure-integrator/issues/16))
+ - Fixed updating properties of the openstack integrator charm do not propagate automatically ([Issue](https://github.com/juju-solutions/charm-openstack-integrator/issues/10))
+ - Fixed flannel error during install hook due to incorrect resource ([Issue](https://github.com/juju-solutions/charm-flannel/issues/52))
+ - Updated master and worker to handle upstream changes from OpenStack Integrator ([Issue](https://github.com/juju-solutions/kubernetes/pull/176))
+ - Updated to CNI 0.7.4 ([Issue](https://github.com/juju-solutions/kubernetes/pull/194))
+ - Updated to Flannel v0.10.0 ([Issue](https://github.com/juju-solutions/charm-flannel/pull/50))
+ - Updated Calico and Canal charms to Calico v2.6.12 ([Issue](https://github.com/juju-solutions/layer-calico/pull/30), [Issue](https://github.com/juju-solutions/layer-canal/pull/27))
+ - Updated to latest CUDA and removed version pins of nvidia-docker stack ([Issue](https://github.com/juju-solutions/layer-docker/pull/123))
+ - Updated to nginx-ingress-controller v0.21.0 ([Issue](https://github.com/juju-solutions/kubernetes/pull/195))
+ - Removed portmap from Calico resource ([Issue](https://github.com/juju-solutions/layer-calico/pull/29))
+ - Removed CNI bins from flannel resource ([Issue](https://github.com/juju-solutions/layer-canal/pull/25))
+
+## Known issues
+
+ - A [current bug](https://github.com/kubernetes/kubernetes/issues/70044) in Kubernetes could prevent the upgrade from properly deleting old pods. `kubectl delete pod <pod_name> --force --grace-period=0` can be used to clean them up.
+ - any remaining major issues currently being worked on
+ - for the next release
+ - if any
+
+## Contact Us
+
+- Issues: https://github.com/juju-solutions/bundle-canonical-kubernetes/issues
+- IRC: #cdk8s on freenode.net
+
+
+
+
 
 ## 1.12 Release Notes
 
@@ -67,4 +158,14 @@ For operators who currently use the `http-proxy`, `https-proxy` and `no-proxy` J
 
 - Issues: <https://github.com/juju-solutions/bundle-canonical-kubernetes/issues>
 
-- IRC: #juju on freenode.net
+- IRC: #cdk8s on freenode.net
+
+
+
+<!--LINKS-->
+
+[docs-ldap]: ../ldap
+[docs-vault]: ../using-vault
+[docs-ear]: ../encryption-at-rest
+[docs-keepalived]: ../keepalived
+[docs-registry]: ../docker-registry


### PR DESCRIPTION
Sorry, I remembered the u.c site is not currently set to process individual files, so I have merged the release notes onto the main release-notes page