### PR TITLE
Change audit logging page tag to match other pages

### DIFF
--- a/pages/k8s/audit-logging.md
+++ b/pages/k8s/audit-logging.md
@@ -6,7 +6,7 @@ context:
   title: "Audit logging"
   description: Accessing and configuring the Kubernetes audit logs with CDK
 keywords: log, audit, config
-tags: [operations]
+tags: [operating]
 sidebar: k8smain-sidebar
 permalink: audit-logging.html
 layout: [base, ubuntu-com]


### PR DESCRIPTION
@evilnick I have no idea if this is of any significance or if this PR is correct, but I noticed that the audit-logging page references an `operations` tag, whereas most of the other pages reference `operating` instead.