### PR TITLE
Add CoreDNS version to release notes and upgrade notes

### DIFF
--- a/pages/k8s/release-notes.md
+++ b/pages/k8s/release-notes.md
@@ -38,7 +38,7 @@ documentation, as well as the [HA overview][haoverview] for more information.
 
 - Added CoreDNS support
 
-All new deployments of **CDK 1.14** will install **CoreDNS** by
+All new deployments of **CDK 1.14** will install **CoreDNS 1.4.0** by
 default instead of **KubeDNS**.
 
 Existing deployments that are upgraded to **CDK 1.14** will

--- a/pages/k8s/upgrade-notes.md
+++ b/pages/k8s/upgrade-notes.md
@@ -24,7 +24,7 @@ any of the intervening steps.
 
 ## Upgrading to 1.14
 
-This upgrade includes support for **CoreDNS**. All new deployments of
+This upgrade includes support for **CoreDNS 1.4.0**. All new deployments of
 **CDK 1.14** will install **CoreDNS** by default instead of **KubeDNS**.
 
 Existing deployments which are upgraded to **CDK 1.14** will continue to use


### PR DESCRIPTION
There's an [issue with CoreDNS 1.3.1](https://github.com/coredns/coredns/issues/2629) and we've [specifically chosen to use CoreDNS 1.4.0 instead](https://github.com/juju-solutions/cdk-addons/pull/84). It's probably good to call out in the release notes which version of CoreDNS we're shipping, for users who might be wondering about it.

I went ahead and put it in the upgrade notes too.